### PR TITLE
Fix icon mapping constant name

### DIFF
--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -3,7 +3,7 @@ import { type JSX, useEffect, useState } from "react";
 import { cn } from "../lib/utils";
 import type { Platform, PlatformDownload } from "../types/platform";
 
-const platform2Icon: Record<"Windows" | "Linux", JSX.Element> = {
+const platformToIcon: Record<PlatformDownload["platform"], JSX.Element> = {
   Windows: <ComputerIcon className="h-8 w-8" />,
   Linux: <LaptopIcon className="h-8 w-8" />,
 };
@@ -70,7 +70,7 @@ export default function Download({
                 )}
               >
                 <div className="mb-4 flex items-center justify-center">
-                  {platform2Icon[platform.platform]}
+                  {platformToIcon[platform.platform]}
                 </div>
                 <h3 className="text-center font-bold text-xl">
                   {platform.platform}


### PR DESCRIPTION
## Summary
- rename `platform2Icon` to `platformToIcon` in `Download`

## Testing
- `npx --yes @biomejs/biome@latest check src/components/Download.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6843fb67d6fc8332b232bca0be886bd4