### PR TITLE
feat: add SHA-256 checksum verification for downloads (#308)

### DIFF
--- a/mocks/fetchLatestRelease.mock.ts
+++ b/mocks/fetchLatestRelease.mock.ts
@@ -1,29 +1,84 @@
 import type { ReleaseData } from "../src/funcs/fetchReleaseData";
 
+const publishedAt = "2026-01-02T03:04:00Z";
+const releaseUrl =
+  "https://github.com/shm11C3/HardwareVisualizer/releases/tag/v1.7.2";
+
 export const mockReleaseData: ReleaseData = {
   version: "1.7.2",
-  published_at: "2026-01-02T03:04:00Z",
+  published_at: publishedAt,
   platforms: {
     windows: {
       url: "https://example.com/fake/windows-installer.msi",
       size: "55.1 MB",
-      name: "HardwareVisualizerInstaller.msi",
+      name: "HardwareVisualizer_1.7.2_x64_en-US.msi",
       browser_download_url: "https://example.com/fake/windows-installer.msi",
-      updated_at: new Date().toISOString(),
+      updated_at: publishedAt,
+      digest:
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      sha256:
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      release_url: releaseUrl,
+      signature_name: "HardwareVisualizer_1.7.2_x64_en-US.msi.sig",
+      signature_url: "https://example.com/fake/windows-installer.msi.sig",
+    },
+    macOSAppleSilicon: {
+      url: "https://example.com/fake/macos-aarch64.dmg",
+      size: "63.5 MB",
+      name: "HardwareVisualizer_1.7.2_aarch64.dmg",
+      browser_download_url: "https://example.com/fake/macos-aarch64.dmg",
+      updated_at: publishedAt,
+      digest:
+        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      sha256:
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      release_url: releaseUrl,
+    },
+    macOSIntel: {
+      url: "https://example.com/fake/macos-x64.dmg",
+      size: "64.1 MB",
+      name: "HardwareVisualizer_1.7.2_x64.dmg",
+      browser_download_url: "https://example.com/fake/macos-x64.dmg",
+      updated_at: publishedAt,
+      digest:
+        "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      sha256:
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      release_url: releaseUrl,
     },
     linuxAppImage: {
       url: "https://example.com/fake/linux.AppImage",
       size: "60.2 MB",
-      name: "HardwareVisualizer.AppImage",
+      name: "HardwareVisualizer_1.7.2_amd64.AppImage",
       browser_download_url: "https://example.com/fake/linux.AppImage",
-      updated_at: new Date().toISOString(),
+      updated_at: publishedAt,
+      digest:
+        "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      sha256:
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      release_url: releaseUrl,
     },
     linuxRPM: {
       url: "https://example.com/fake/linux.rpm",
       size: "50.3 MB",
-      name: "HardwareVisualizer.rpm",
+      name: "HardwareVisualizer-1.7.2-1.x86_64.rpm",
       browser_download_url: "https://example.com/fake/linux.rpm",
-      updated_at: new Date().toISOString(),
+      updated_at: publishedAt,
+      digest:
+        "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      sha256:
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      release_url: releaseUrl,
+    },
+    linuxDeb: {
+      url: "https://example.com/fake/linux.deb",
+      size: "51.8 MB",
+      name: "hardwarevisualizer_1.7.2_amd64.deb",
+      browser_download_url: "https://example.com/fake/linux.deb",
+      updated_at: publishedAt,
+      digest: null,
+      sha256: null,
+      release_url: releaseUrl,
     },
   },
 };

--- a/src/components/CopyableCode.astro
+++ b/src/components/CopyableCode.astro
@@ -1,0 +1,122 @@
+---
+import { Code } from "astro:components";
+import { Check, Copy } from "lucide-react";
+
+interface Props {
+  code: string;
+  lang: "bash" | "plaintext" | "powershell";
+  class?: string;
+  copyLabel: string;
+  copiedLabel: string;
+}
+
+const { code, lang, class: className, copyLabel, copiedLabel } = Astro.props;
+---
+
+<div class="group/code relative min-w-0" data-copyable-code>
+  <Code code={code} lang={lang} class={className} />
+  <button
+    type="button"
+    class="group/copy absolute top-1 right-2 inline-flex h-7 w-7 items-center justify-center rounded-md border border-slate-300/15 bg-slate-500/20 text-slate-100 backdrop-blur-[2px] transition-colors hover:border-slate-200/30 hover:bg-slate-400/30 hover:text-white focus-visible:outline-2 focus-visible:outline-cyan-500 focus-visible:outline-offset-2"
+    aria-label={copyLabel}
+    title={copyLabel}
+    data-copy-code-button
+    data-copy-label={copyLabel}
+    data-copied-label={copiedLabel}
+  >
+    <span data-copy-idle>
+      <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+    </span>
+    <span class="hidden" data-copy-done>
+      <Check className="h-3.5 w-3.5" aria-hidden="true" />
+    </span>
+    <span
+      class="pointer-events-none absolute right-0 bottom-full z-20 mb-2 hidden whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 font-medium text-white text-xs shadow-lg group-hover/copy:block group-focus-visible/copy:block dark:bg-slate-100 dark:text-slate-900"
+      data-copy-tooltip
+    >
+      {copyLabel}
+    </span>
+  </button>
+</div>
+
+<script>
+const resetTimers = new WeakMap<HTMLButtonElement, number>();
+
+async function writeClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  document.body.append(textarea);
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    textarea.remove();
+  }
+}
+
+function setCopiedState(button: HTMLButtonElement, copied: boolean) {
+  const copyLabel = button.dataset.copyLabel ?? "Copy";
+  const copiedLabel = button.dataset.copiedLabel ?? "Copied";
+  const label = copied ? copiedLabel : copyLabel;
+  const idleIcon = button.querySelector<HTMLElement>("[data-copy-idle]");
+  const doneIcon = button.querySelector<HTMLElement>("[data-copy-done]");
+  const tooltip = button.querySelector<HTMLElement>("[data-copy-tooltip]");
+
+  idleIcon?.classList.toggle("hidden", copied);
+  doneIcon?.classList.toggle("hidden", !copied);
+  button.setAttribute("aria-label", label);
+  button.title = label;
+
+  if (tooltip) {
+    tooltip.textContent = label;
+  }
+}
+
+for (const button of document.querySelectorAll<HTMLButtonElement>(
+  "[data-copy-code-button]",
+)) {
+  if (button.dataset.copyCodeReady === "true") {
+    continue;
+  }
+
+  button.dataset.copyCodeReady = "true";
+  button.addEventListener("click", async () => {
+    const codeBlock = button
+      .closest("[data-copyable-code]")
+      ?.querySelector("pre code");
+    const code = codeBlock?.textContent?.trimEnd();
+
+    if (!code) {
+      return;
+    }
+
+    try {
+      if (!(await writeClipboard(code))) {
+        return;
+      }
+    } catch {
+      return;
+    }
+
+    const previousTimer = resetTimers.get(button);
+    if (previousTimer) {
+      window.clearTimeout(previousTimer);
+    }
+
+    setCopiedState(button, true);
+    resetTimers.set(
+      button,
+      window.setTimeout(() => setCopiedState(button, false), 1600),
+    );
+  });
+}
+</script>

--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -1,4 +1,11 @@
-import { ArrowRight, CalendarDays, Sparkles } from "lucide-react";
+import {
+  ArrowRight,
+  CalendarDays,
+  Check,
+  ChevronRight,
+  Copy as CopyIcon,
+  Sparkles,
+} from "lucide-react";
 import { type JSX, memo, useEffect, useState } from "react";
 import { FaApple, FaGithub, FaLinux, FaWindows } from "react-icons/fa";
 import type { LatestReleaseDetails } from "../lib/latestRelease";
@@ -11,7 +18,14 @@ const platformToIcon: Record<PlatformDownload["platform"], JSX.Element> = {
   macOS: <FaApple className="h-8 w-8" />,
 };
 
-interface DownloadTranslations {
+interface DownloadChecksumTranslations {
+  sha256: string;
+  copySha256: string;
+  copied: string;
+  checksumUnavailable: string;
+}
+
+interface DownloadTranslations extends Partial<DownloadChecksumTranslations> {
   button: string;
   noDownloads: string;
   title?: string;
@@ -25,6 +39,23 @@ interface DownloadTranslations {
   latestChanges?: string;
   latestChangesLink?: string;
 }
+
+const getChecksumTranslations = (
+  translations: DownloadTranslations,
+): DownloadChecksumTranslations | null => {
+  const { sha256, copySha256, copied, checksumUnavailable } = translations;
+
+  if (!sha256 || !copySha256 || !copied || !checksumUnavailable) {
+    return null;
+  }
+
+  return {
+    sha256,
+    copySha256,
+    copied,
+    checksumUnavailable,
+  };
+};
 
 const Download = ({
   downloads: initialDownloads,
@@ -54,6 +85,8 @@ const Download = ({
   const [detectedPlatform, setDetectedPlatform] = useState<
     PlatformDownload["platform"] | null
   >(null);
+  const [copiedArtifact, setCopiedArtifact] = useState<string | null>(null);
+  const checksumLabels = getChecksumTranslations(translations);
 
   useEffect(() => {
     const ua = navigator.userAgent;
@@ -65,6 +98,24 @@ const Download = ({
       setDetectedPlatform("Windows");
     }
   }, []);
+
+  const copySha256 = async (artifactName: string, sha256: string) => {
+    if (!navigator.clipboard?.writeText) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(sha256);
+      setCopiedArtifact(artifactName);
+      window.setTimeout(() => {
+        setCopiedArtifact((current) =>
+          current === artifactName ? null : current,
+        );
+      }, 1800);
+    } catch {
+      setCopiedArtifact(null);
+    }
+  };
 
   const downloads = initialDownloads.map((platform) => ({
     ...platform,
@@ -168,6 +219,84 @@ const Download = ({
                       </div>
                     )}
                   </div>
+                  {checksumLabels && version.url ? (
+                    <details
+                      className="group/checksum relative z-20 mt-4 overflow-visible rounded-lg border border-slate-200 bg-slate-50/80 text-sm dark:border-slate-700 dark:bg-slate-900/40"
+                      data-download-checksum={version.type}
+                    >
+                      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 [&::-webkit-details-marker]:hidden">
+                        <span className="flex min-w-0 items-center gap-2">
+                          <ChevronRight
+                            className="h-4 w-4 shrink-0 text-slate-500 transition-transform group-open/checksum:rotate-90 dark:text-slate-400"
+                            aria-hidden="true"
+                          />
+                          <span className="font-medium text-slate-600 text-xs uppercase dark:text-slate-400">
+                            {checksumLabels.sha256}
+                          </span>
+                        </span>
+                        {version.sha256 ? (
+                          <button
+                            type="button"
+                            className="group/copy relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-slate-300 text-slate-600 hover:bg-white hover:text-slate-900 focus-visible:outline-2 focus-visible:outline-cyan-500 focus-visible:outline-offset-2 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800 dark:hover:text-white"
+                            aria-label={
+                              copiedArtifact ===
+                              (version.artifactName ?? version.type)
+                                ? checksumLabels.copied
+                                : checksumLabels.copySha256
+                            }
+                            title={
+                              copiedArtifact ===
+                              (version.artifactName ?? version.type)
+                                ? checksumLabels.copied
+                                : checksumLabels.copySha256
+                            }
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              void copySha256(
+                                version.artifactName ?? version.type,
+                                version.sha256 ?? "",
+                              );
+                            }}
+                          >
+                            {copiedArtifact ===
+                            (version.artifactName ?? version.type) ? (
+                              <Check className="h-4 w-4" aria-hidden="true" />
+                            ) : (
+                              <CopyIcon
+                                className="h-4 w-4"
+                                aria-hidden="true"
+                              />
+                            )}
+                            <span
+                              className="pointer-events-none absolute right-0 bottom-full z-50 mb-2 hidden whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 font-medium text-white text-xs shadow-lg group-hover/copy:block group-focus-visible/copy:block dark:bg-slate-100 dark:text-slate-900"
+                              aria-hidden="true"
+                              data-copy-tooltip
+                            >
+                              {copiedArtifact ===
+                              (version.artifactName ?? version.type)
+                                ? checksumLabels.copied
+                                : checksumLabels.copySha256}
+                            </span>
+                          </button>
+                        ) : null}
+                      </summary>
+                      <div className="border-slate-200 border-t p-3 dark:border-slate-700">
+                        {version.sha256 ? (
+                          <code className="block overflow-x-auto break-all rounded bg-white px-2 py-1.5 font-mono text-slate-900 text-xs dark:bg-slate-950 dark:text-slate-100">
+                            {version.sha256}
+                          </code>
+                        ) : (
+                          <div
+                            className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-800 text-sm dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100"
+                            data-checksum-warning
+                          >
+                            {checksumLabels.checksumUnavailable}
+                          </div>
+                        )}
+                      </div>
+                    </details>
+                  ) : null}
                 </div>
               ))}
               {platform.versions.length === 0 && (

--- a/src/components/DownloadPage.astro
+++ b/src/components/DownloadPage.astro
@@ -48,6 +48,10 @@ const guideArticleClass =
 const downloadTranslations = {
   button: t("download.button"),
   noDownloads: t("download.noDownloads"),
+  sha256: t("download.verify.sha256"),
+  copySha256: t("download.verify.copySha256"),
+  copied: t("download.verify.copied"),
+  checksumUnavailable: t("download.verify.checksumUnavailable"),
 };
 
 const pageTitleSeparator = t("download.pageTitleSeparator");

--- a/src/components/DownloadVerificationPage.astro
+++ b/src/components/DownloadVerificationPage.astro
@@ -1,8 +1,12 @@
 ---
 import { render } from "astro:content";
+import { Info } from "lucide-react";
 import type { ui } from "../i18n/ui";
+import { useTranslations } from "../i18n/utils";
 import type { DownloadGuideEntry } from "../lib/downloadGuide";
 import { addJapaneseLineBreaks } from "../lib/japaneseLineBreaks";
+import type { PlatformDownload } from "../types/platform";
+import CopyableCode from "./CopyableCode.astro";
 import DownloadGuideNav from "./DownloadGuideNav.astro";
 
 interface Props {
@@ -10,14 +14,33 @@ interface Props {
   entry: DownloadGuideEntry;
   downloadHref: string;
   verificationHref: string;
+  downloads: PlatformDownload[];
 }
 
-const { lang, entry, downloadHref, verificationHref } = Astro.props;
+const { lang, entry, downloadHref, verificationHref, downloads } = Astro.props;
 const { Content } = await render(entry as never);
+const t = useTranslations(lang);
 const formatText = (text: string) => addJapaneseLineBreaks(lang, text);
+const commandEntries = downloads.flatMap((download) =>
+  download.versions.flatMap((version) => {
+    if (!version.artifactName) {
+      return [];
+    }
+
+    return [
+      {
+        artifactName: version.artifactName,
+        platform: download.platform,
+        version,
+      },
+    ];
+  }),
+);
 
 const guideArticleClass =
   "prose prose-sm prose-slate max-w-full min-w-0 sm:prose-base dark:prose-invert prose-a:text-cyan-700 dark:prose-a:text-cyan-300 prose-blockquote:border-cyan-500 prose-code:break-words prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:whitespace-pre prose-pre:rounded-none prose-pre:border-slate-800 prose-pre:border-l-4 prose-pre:bg-slate-950 prose-pre:text-cyan-100 prose-pre:text-[0.8125rem] sm:prose-pre:text-sm";
+const codeBlockClass =
+  "m-0 max-w-full overflow-x-auto whitespace-pre rounded-none border-slate-800 border-l-4 bg-[#24292e] py-2 pr-12 pl-3 font-mono text-[#e1e4e8] text-[0.8125rem] sm:text-sm";
 ---
 
 <section id="verification" class="bg-white pt-16 pb-20 dark:bg-slate-800">
@@ -38,11 +61,143 @@ const guideArticleClass =
         >
           {formatText(entry.data.title)}
         </h1>
+        <aside
+          class:list={[
+            "mt-6 rounded-lg border border-cyan-200 bg-cyan-50/80 p-4 text-slate-800 dark:border-cyan-500/30 dark:bg-cyan-500/10 dark:text-slate-100",
+            lang === "ja" && "budoux-ja",
+          ]}
+          data-verification-info
+        >
+          <div class="min-w-0">
+            <div class="flex items-center gap-2">
+              <Info
+                className="h-4 w-4 shrink-0 text-cyan-700 dark:text-cyan-300"
+                aria-hidden="true"
+              />
+              <p class="font-semibold text-cyan-900 text-xs dark:text-cyan-100">
+                {t("download.verificationPage.infoLabel")}
+              </p>
+            </div>
+            <p class="mt-2 text-sm leading-6">
+              {formatText(t("download.verificationPage.beginnerInfo"))}
+            </p>
+          </div>
+        </aside>
         <article
           class:list={[guideArticleClass, "mt-8", lang === "ja" && "budoux-ja"]}
         >
           <Content />
         </article>
+
+        {commandEntries.length ? (
+            <section class="mt-12 min-w-0" aria-labelledby="latest-commands">
+              <h2
+                id="latest-commands"
+                class="font-bold text-2xl text-slate-950 leading-tight dark:text-white"
+              >
+                {formatText(t("download.verificationPage.latestCommandsTitle"))}
+              </h2>
+              <p class="mt-3 text-slate-600 text-sm leading-6 dark:text-slate-300">
+                {formatText(
+                  t("download.verificationPage.latestCommandsDescription"),
+                )}
+              </p>
+
+              <div class="mt-6 space-y-4">
+                {commandEntries.map(({ artifactName, platform, version }) => (
+                  <article class="min-w-0 rounded-lg border border-slate-200 bg-slate-50/80 p-4 dark:border-slate-700 dark:bg-slate-900/30">
+                    <h3 class="font-semibold text-slate-950 text-sm dark:text-white">
+                      {platform} - {version.name}
+                    </h3>
+                    <dl class="mt-4 space-y-4">
+                      <div class="min-w-0">
+                        <dt class="mb-1 font-medium text-slate-500 text-xs uppercase dark:text-slate-400">
+                          {t("download.verify.artifact")}
+                        </dt>
+                        <dd>
+                          <CopyableCode
+                            code={artifactName}
+                            lang="plaintext"
+                            class={codeBlockClass}
+                            copyLabel={t("download.verify.copyCode")}
+                            copiedLabel={t("download.verify.copied")}
+                          />
+                        </dd>
+                      </div>
+
+                      {version.verificationCommand ? (
+                        <div class="min-w-0">
+                          <dt class="mb-1 font-medium text-slate-500 text-xs uppercase dark:text-slate-400">
+                            {t("download.verify.verificationCommand")}
+                          </dt>
+                          <dd>
+                            <CopyableCode
+                              code={version.verificationCommand}
+                              lang={
+                                version.type === "windows"
+                                  ? "powershell"
+                                  : "bash"
+                              }
+                              class={codeBlockClass}
+                              copyLabel={t("download.verify.copyCode")}
+                              copiedLabel={t("download.verify.copied")}
+                            />
+                          </dd>
+                        </div>
+                      ) : null}
+
+                      {version.attestationCommand ? (
+                        <div class="min-w-0">
+                          <dt class="mb-1 font-medium text-slate-500 text-xs uppercase dark:text-slate-400">
+                            {t("download.verify.githubAttestation")}
+                          </dt>
+                          <dd>
+                            <CopyableCode
+                              code={version.attestationCommand}
+                              lang="bash"
+                              class={codeBlockClass}
+                              copyLabel={t("download.verify.copyCode")}
+                              copiedLabel={t("download.verify.copied")}
+                            />
+                          </dd>
+                        </div>
+                      ) : null}
+
+                      <div class="min-w-0">
+                        <dt class="mb-1 font-medium text-slate-500 text-xs uppercase dark:text-slate-400">
+                          {t("download.verify.signingStatus")}
+                        </dt>
+                        <dd class="text-slate-700 text-sm dark:text-slate-200">
+                          {version.signingStatus}
+                        </dd>
+                      </div>
+
+                      {version.signatureName && version.signatureUrl ? (
+                        <div class="min-w-0">
+                          <dt class="mb-1 font-medium text-slate-500 text-xs uppercase dark:text-slate-400">
+                            {t("download.verify.signatureFile")}
+                          </dt>
+                          <dd>
+                            <a
+                              href={version.signatureUrl}
+                              class="break-all font-medium text-cyan-700 text-sm hover:underline dark:text-cyan-300"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {version.signatureName}
+                            </a>
+                            <p class="mt-1 text-slate-500 text-xs dark:text-slate-400">
+                              {t("download.verify.updaterSignatureAvailable")}
+                            </p>
+                          </dd>
+                        </div>
+                      ) : null}
+                    </dl>
+                  </article>
+                ))}
+              </div>
+            </section>
+          ) : null}
       </div>
     </div>
   </div>

--- a/src/content/download-guide/en/verification.mdx
+++ b/src/content/download-guide/en/verification.mdx
@@ -12,12 +12,14 @@ Official downloads are available only from hardviz.com, GitHub Releases, and Win
 
 ### Check that the file has not been changed
 
-When a release provides a checksum, compare your installer with the SHA-256 value published in the matching GitHub Release.
+For a stricter check, copy the SHA-256 value from the download page, then run the matching checksum command from the [latest release verification commands](#latest-commands).
+The command output should match the copied value exactly.
 For details, see [Installer verification in the GitHub documentation](https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/download-verification.md).
 
 ### Verify GitHub Artifact Attestations
 
 For releases that publish attestations, use GitHub CLI to verify that the asset was produced by the official repository.
+The latest release commands are listed below.
 
 ```bash
 gh attestation verify ./HardwareVisualizer_* -R shm11C3/HardwareVisualizer

--- a/src/content/download-guide/ja/verification.mdx
+++ b/src/content/download-guide/ja/verification.mdx
@@ -12,12 +12,14 @@ title: "インストーラの検証"
 
 ### ファイルが改ざんされていないか確認する
 
-チェックサム（SHA-256）が公開されているリリースでは、インストーラと同じGitHub Releaseに掲載された値と照合してください。
+より厳密に確認したい場合は、ダウンロードページからSHA-256の値をコピーし、[最新リリースの検証コマンド](#latest-commands)から対象ファイルに合うものを実行してください。
+コマンドの出力がコピーした値と完全に一致することを確認してください。
 詳しくはGitHubドキュメントに記載の[インストーラの検証](https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/download-verification.ja.md)を参照してください。
 
 ### GitHub Artifact Attestationsを検証する
 
 attestationが公開されているリリースでは、GitHub CLIでアセットが公式リポジトリから生成されたことを確認してください。
+最新リリース向けのコマンドは下に掲載しています。
 
 ```bash
 gh attestation verify ./HardwareVisualizer_* -R shm11C3/HardwareVisualizer

--- a/src/funcs/fetchReleaseData.ts
+++ b/src/funcs/fetchReleaseData.ts
@@ -4,17 +4,24 @@ import { fetchLatestReleaseMock } from "../../mocks/fetchLatestRelease.mock";
 import type { GitHubRelease } from "../types/github";
 import type { Platform } from "../types/platform";
 
+export interface ReleasePlatformAsset {
+  url: string;
+  size: string;
+  name: string;
+  browser_download_url: string;
+  updated_at: string;
+  digest: string | null;
+  sha256: string | null;
+  release_url: string;
+  signature_name?: string;
+  signature_url?: string;
+}
+
 export interface ReleaseData {
   version: string;
   published_at: string | null;
   platforms: {
-    [K in Platform]?: {
-      url: string;
-      size: string;
-      name: string;
-      browser_download_url: string;
-      updated_at: string;
-    };
+    [K in Platform]?: ReleasePlatformAsset;
   };
 }
 
@@ -46,83 +53,114 @@ function writeCache(data: ReleaseData): void {
   }
 }
 
-function parseRelease(data: GitHubRelease): ReleaseData {
-  const platforms = (data.assets || []).reduce(
-    (
-      acc: ReleaseData["platforms"],
-      asset: { name: string; browser_download_url: string; size?: number },
-    ) => {
-      if (
-        /.msi/.test(asset.name) &&
-        !/offline/.test(asset.name) &&
-        !/.sig/.test(asset.name)
-      ) {
-        acc.windows = {
-          url: asset.browser_download_url,
-          size: asset.size
-            ? `${(asset.size / 1024 / 1024).toFixed(1)} MB`
-            : "-",
-          name: asset.name,
-          browser_download_url: asset.browser_download_url,
-          updated_at: data.published_at,
-        };
-      } else if (/.rpm/.test(asset.name) && !/.sig/.test(asset.name)) {
-        acc.linuxRPM = {
-          url: asset.browser_download_url,
-          size: asset.size
-            ? `${(asset.size / 1024 / 1024).toFixed(1)} MB`
-            : "-",
-          name: asset.name,
-          browser_download_url: asset.browser_download_url,
-          updated_at: data.published_at,
-        };
-      } else if (/.AppImage/.test(asset.name) && !/.sig/.test(asset.name)) {
-        acc.linuxAppImage = {
-          url: asset.browser_download_url,
-          size: asset.size
-            ? `${(asset.size / 1024 / 1024).toFixed(1)} MB`
-            : "-",
-          name: asset.name,
-          browser_download_url: asset.browser_download_url,
-          updated_at: data.published_at,
-        };
-      } else if (/.deb/.test(asset.name) && !/.sig/.test(asset.name)) {
-        acc.linuxDeb = {
-          url: asset.browser_download_url,
-          size: asset.size
-            ? `${(asset.size / 1024 / 1024).toFixed(1)} MB`
-            : "-",
-          name: asset.name,
-          browser_download_url: asset.browser_download_url,
-          updated_at: data.published_at,
-        };
-      } else if (/.dmg/.test(asset.name) && !/.sig/.test(asset.name)) {
-        if (/arm64|aarch64/i.test(asset.name)) {
-          acc.macOSAppleSilicon = {
-            url: asset.browser_download_url,
-            size: asset.size
-              ? `${(asset.size / 1024 / 1024).toFixed(1)} MB`
-              : "-",
-            name: asset.name,
-            browser_download_url: asset.browser_download_url,
-            updated_at: data.published_at,
-          };
-        } else if (/x64|x86.?64|intel/i.test(asset.name)) {
-          acc.macOSIntel = {
-            url: asset.browser_download_url,
-            size: asset.size
-              ? `${(asset.size / 1024 / 1024).toFixed(1)} MB`
-              : "-",
-            name: asset.name,
-            browser_download_url: asset.browser_download_url,
-            updated_at: data.published_at,
-          };
+type GitHubReleaseAsset = GitHubRelease["assets"][number];
+
+function formatAssetSize(size: number | undefined): string {
+  return typeof size === "number"
+    ? `${(size / 1024 / 1024).toFixed(1)} MB`
+    : "-";
+}
+
+function parseSha256Digest(digest: string | null | undefined): string | null {
+  if (!digest?.startsWith("sha256:")) {
+    return null;
+  }
+
+  const sha256 = digest.slice("sha256:".length);
+  return /^[a-fA-F0-9]{64}$/.test(sha256) ? sha256.toLowerCase() : null;
+}
+
+function isSignatureAsset(asset: GitHubReleaseAsset): boolean {
+  return asset.name.toLowerCase().endsWith(".sig");
+}
+
+function platformForAsset(asset: GitHubReleaseAsset): Platform | null {
+  const name = asset.name;
+  const lowerName = name.toLowerCase();
+
+  if (isSignatureAsset(asset)) {
+    return null;
+  }
+
+  if (lowerName.endsWith(".msi") && !lowerName.includes("offline")) {
+    return "windows";
+  }
+
+  if (lowerName.endsWith(".rpm")) {
+    return "linuxRPM";
+  }
+
+  if (name.endsWith(".AppImage")) {
+    return "linuxAppImage";
+  }
+
+  if (lowerName.endsWith(".deb")) {
+    return "linuxDeb";
+  }
+
+  if (lowerName.endsWith(".dmg")) {
+    if (/arm64|aarch64/i.test(name)) {
+      return "macOSAppleSilicon";
+    }
+
+    if (/x64|x86.?64|intel/i.test(name)) {
+      return "macOSIntel";
+    }
+  }
+
+  return null;
+}
+
+function toReleasePlatformAsset(
+  asset: GitHubReleaseAsset,
+  releaseUrl: string,
+  signatureAsset: GitHubReleaseAsset | undefined,
+): ReleasePlatformAsset {
+  return {
+    url: asset.browser_download_url,
+    size: formatAssetSize(asset.size),
+    name: asset.name,
+    browser_download_url: asset.browser_download_url,
+    updated_at: asset.updated_at,
+    digest: asset.digest ?? null,
+    sha256: parseSha256Digest(asset.digest),
+    release_url: releaseUrl,
+    ...(signatureAsset
+      ? {
+          signature_name: signatureAsset.name,
+          signature_url: signatureAsset.browser_download_url,
         }
+      : {}),
+  };
+}
+
+function parseRelease(data: GitHubRelease): ReleaseData {
+  const signatureAssets = new Map<string, GitHubReleaseAsset>();
+
+  for (const asset of data.assets || []) {
+    if (isSignatureAsset(asset)) {
+      signatureAssets.set(asset.name.slice(0, -".sig".length), asset);
+    }
+  }
+
+  const platforms = (data.assets || []).reduce(
+    (acc: ReleaseData["platforms"], asset) => {
+      const platform = platformForAsset(asset);
+
+      if (!platform) {
+        return acc;
       }
+
+      acc[platform] = toReleasePlatformAsset(
+        asset,
+        data.html_url,
+        signatureAssets.get(asset.name),
+      );
       return acc;
     },
     {},
   );
+
   return {
     version: data.tag_name?.replace(/^v/, "") || data.name,
     published_at: data.published_at ?? null,

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -84,6 +84,13 @@ export const ui = {
     "download.verificationPage.metaTitle": "Installer verification",
     "download.verificationPage.metaDescription":
       "Installer verification for HardwareVisualizer, including official sources, SHA-256 checksums, GitHub Artifact Attestations, and code signing status.",
+    "download.verificationPage.latestCommandsTitle":
+      "Latest release verification commands (Advanced)",
+    "download.verificationPage.latestCommandsDescription":
+      "Copy the SHA-256 value from the download page, then run the command for the file you downloaded.",
+    "download.verificationPage.infoLabel": "Info",
+    "download.verificationPage.beginnerInfo":
+      "SHA-256 is a value used to check whether the file you downloaded is the same as the file that was published. If you are not comfortable using command-line tools, you do not need to force this step. First make sure you downloaded the installer from an official source.",
     "download.currentVersion": "Current version:",
     "download.button": "Download",
     "download.noDownloads": "No downloads available for {platform} yet.",
@@ -95,6 +102,20 @@ export const ui = {
     "download.releaseDate": "Released:",
     "download.latestChanges": "Latest release changes",
     "download.latestChangesLink": "Read full changelog →",
+    "download.verify.summary": "Verify this download",
+    "download.verify.artifact": "Artifact",
+    "download.verify.fileSize": "File size",
+    "download.verify.sha256": "Checksum (SHA-256)",
+    "download.verify.copySha256": "Copy SHA-256",
+    "download.verify.copyCode": "Copy code",
+    "download.verify.copied": "Copied",
+    "download.verify.checksumUnavailable": "Checksum unavailable",
+    "download.verify.verificationCommand": "Verification command",
+    "download.verify.githubAttestation": "GitHub attestation",
+    "download.verify.signatureFile": "Signature file",
+    "download.verify.signingStatus": "Signing status",
+    "download.verify.updaterSignatureAvailable":
+      "Tauri updater signature available.",
 
     "changelog.title": "Changelog",
     "changelog.description":
@@ -273,6 +294,13 @@ export const ui = {
     "download.verificationPage.metaTitle": "インストーラの検証",
     "download.verificationPage.metaDescription":
       "HardwareVisualizerのインストーラの検証として、公式配布元、SHA-256チェックサム、GitHub Artifact Attestations、コード署名状況の確認方法を案内します。",
+    "download.verificationPage.latestCommandsTitle":
+      "最新リリースの検証コマンド（上級者向け）",
+    "download.verificationPage.latestCommandsDescription":
+      "ダウンロードページからSHA-256の値をコピーし、取得したファイルに対応するコマンドを実行してください。",
+    "download.verificationPage.infoLabel": "Info",
+    "download.verificationPage.beginnerInfo":
+      "SHA-256は、ダウンロードしたファイルが配布時と同じか確認するための値です。コマンド操作に慣れていない場合は、この手順を無理に実行する必要はありません。まず公式配布元から入手していることを確認してください。",
     "download.currentVersion": "現在のバージョン:",
     "download.button": "ダウンロード",
     "download.noDownloads": "{platform}用のダウンロードはまだ利用できません。",
@@ -285,6 +313,20 @@ export const ui = {
     "download.releaseDate": "リリース日時:",
     "download.latestChanges": "最新リリースの変更内容",
     "download.latestChangesLink": "変更履歴を詳しく見る →",
+    "download.verify.summary": "このダウンロードを検証する",
+    "download.verify.artifact": "アーティファクト",
+    "download.verify.fileSize": "ファイルサイズ",
+    "download.verify.sha256": "チェックサム (SHA-256)",
+    "download.verify.copySha256": "SHA-256をコピー",
+    "download.verify.copyCode": "コードをコピー",
+    "download.verify.copied": "コピーしました",
+    "download.verify.checksumUnavailable": "チェックサムを取得できません",
+    "download.verify.verificationCommand": "検証コマンド",
+    "download.verify.githubAttestation": "GitHub Attestation",
+    "download.verify.signatureFile": "署名ファイル",
+    "download.verify.signingStatus": "署名状態",
+    "download.verify.updaterSignatureAvailable":
+      "Tauriアップデータ署名を利用できます。",
 
     "changelog.title": "変更履歴",
     "changelog.description": "HardwareVisualizerのリリースノートと更新情報。",

--- a/src/lib/platformDownloads.ts
+++ b/src/lib/platformDownloads.ts
@@ -1,5 +1,35 @@
 import type { ReleaseData } from "../funcs/fetchReleaseData";
-import type { PlatformDownload } from "../types/platform";
+import type {
+  Platform,
+  PlatformDownload,
+  VersionInfo,
+} from "../types/platform";
+
+const HARDVIZ_RELEASE_REPO = "shm11C3/HardwareVisualizer";
+
+function verificationCommandFor(type: Platform, artifactName: string): string {
+  if (type === "windows") {
+    return `Get-FileHash .\\${artifactName} -Algorithm SHA256`;
+  }
+
+  if (type === "macOSAppleSilicon" || type === "macOSIntel") {
+    return `shasum -a 256 ${artifactName}`;
+  }
+
+  return `sha256sum ${artifactName}`;
+}
+
+function signingStatusFor(type: Platform): string {
+  if (type === "windows") {
+    return "Authenticode signing pending";
+  }
+
+  if (type === "macOSAppleSilicon" || type === "macOSIntel") {
+    return "Signed and notarized";
+  }
+
+  return "Package signing not implemented yet";
+}
 
 export function createPlatformDownloads(
   release: ReleaseData,
@@ -7,61 +37,83 @@ export function createPlatformDownloads(
 ): PlatformDownload[] {
   const urlFor = (url: string | null | undefined) =>
     url ? (overrideDownloadHref ?? url) : null;
+  const versionFor = ({
+    type,
+    name,
+  }: {
+    type: Platform;
+    name: string;
+  }): VersionInfo => {
+    const asset = release.platforms[type];
+    const artifactName = asset?.name ?? null;
+
+    return {
+      type,
+      name,
+      url: urlFor(asset?.browser_download_url),
+      size: asset?.size ?? "-",
+      artifactName,
+      sha256: asset?.sha256 ?? null,
+      digest: asset?.digest ?? null,
+      releaseUrl: asset?.release_url ?? null,
+      verificationCommand: artifactName
+        ? verificationCommandFor(type, artifactName)
+        : null,
+      attestationCommand: artifactName
+        ? `gh attestation verify ./${artifactName} -R ${HARDVIZ_RELEASE_REPO}`
+        : null,
+      signingStatus: signingStatusFor(type),
+      ...(asset?.signature_name ? { signatureName: asset.signature_name } : {}),
+      ...(asset?.signature_url ? { signatureUrl: asset.signature_url } : {}),
+      ...(type === "windows"
+        ? {
+            recommendedInstallCommand:
+              "winget install shm11C3.HardwareVisualizer",
+          }
+        : {}),
+    };
+  };
 
   return [
     {
       platform: "Windows",
       versions: [
-        {
+        versionFor({
           type: "windows",
           name: "Windows 10/11 (x64)",
-          url: urlFor(release.platforms.windows?.browser_download_url),
-          size: release.platforms.windows?.size ?? "-",
-        },
+        }),
       ],
       primary: false,
     },
     {
       platform: "macOS",
       versions: [
-        {
+        versionFor({
           type: "macOSAppleSilicon",
           name: "Apple Silicon (ARM64)",
-          url: urlFor(
-            release.platforms.macOSAppleSilicon?.browser_download_url,
-          ),
-          size: release.platforms.macOSAppleSilicon?.size ?? "-",
-        },
-        {
+        }),
+        versionFor({
           type: "macOSIntel",
           name: "Intel (x64)",
-          url: urlFor(release.platforms.macOSIntel?.browser_download_url),
-          size: release.platforms.macOSIntel?.size ?? "-",
-        },
+        }),
       ],
       primary: false,
     },
     {
       platform: "Linux",
       versions: [
-        {
+        versionFor({
           type: "linuxRPM",
           name: "RPM-based Distros (.rpm)",
-          url: urlFor(release.platforms.linuxRPM?.browser_download_url),
-          size: release.platforms.linuxRPM?.size ?? "-",
-        },
-        {
+        }),
+        versionFor({
           type: "linuxAppImage",
           name: "AppImage (.AppImage)",
-          url: urlFor(release.platforms.linuxAppImage?.browser_download_url),
-          size: release.platforms.linuxAppImage?.size ?? "-",
-        },
-        {
+        }),
+        versionFor({
           type: "linuxDeb",
           name: "Debian/Ubuntu (.deb)",
-          url: urlFor(release.platforms.linuxDeb?.browser_download_url),
-          size: release.platforms.linuxDeb?.size ?? "-",
-        },
+        }),
       ],
       primary: false,
     },

--- a/src/pages/ja/verification.astro
+++ b/src/pages/ja/verification.astro
@@ -2,6 +2,7 @@
 import DownloadVerificationPage from "../../components/DownloadVerificationPage.astro";
 import Footer from "../../components/Footer.astro";
 import Header from "../../components/Header.astro";
+import { fetchLatestRelease } from "../../funcs/fetchReleaseData";
 import {
   getLangFromUrl,
   useTranslatedPath,
@@ -9,11 +10,14 @@ import {
 } from "../../i18n/utils";
 import Layout from "../../layouts/Layout.astro";
 import { getDownloadGuideEntry } from "../../lib/downloadGuide";
+import { createPlatformDownloads } from "../../lib/platformDownloads";
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 const { translatePath } = useTranslatedPath(lang);
 const entry = await getDownloadGuideEntry(lang, "verification");
+const release = await fetchLatestRelease();
+const downloads = createPlatformDownloads(release);
 ---
 
 <Layout
@@ -26,6 +30,7 @@ const entry = await getDownloadGuideEntry(lang, "verification");
     <DownloadVerificationPage
       lang={lang}
       entry={entry}
+      downloads={downloads}
       downloadHref={translatePath("/download")}
       verificationHref={translatePath("/verification")}
     />

--- a/src/pages/verification.astro
+++ b/src/pages/verification.astro
@@ -2,6 +2,7 @@
 import DownloadVerificationPage from "../components/DownloadVerificationPage.astro";
 import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
+import { fetchLatestRelease } from "../funcs/fetchReleaseData";
 import {
   getLangFromUrl,
   useTranslatedPath,
@@ -9,11 +10,14 @@ import {
 } from "../i18n/utils";
 import Layout from "../layouts/Layout.astro";
 import { getDownloadGuideEntry } from "../lib/downloadGuide";
+import { createPlatformDownloads } from "../lib/platformDownloads";
 
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 const { translatePath } = useTranslatedPath(lang);
 const entry = await getDownloadGuideEntry(lang, "verification");
+const release = await fetchLatestRelease();
+const downloads = createPlatformDownloads(release);
 ---
 
 <Layout
@@ -26,6 +30,7 @@ const entry = await getDownloadGuideEntry(lang, "verification");
     <DownloadVerificationPage
       lang={lang}
       entry={entry}
+      downloads={downloads}
       downloadHref={translatePath("/download")}
       verificationHref={translatePath("/verification")}
     />

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -46,6 +46,7 @@ export interface GitHubRelease {
     created_at: string;
     updated_at: string;
     browser_download_url: string;
+    digest?: string | null;
   }>;
   tarball_url: string;
   zipball_url: string;

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -11,6 +11,16 @@ export type VersionInfo = {
   name: string;
   url: string | null;
   size: string;
+  artifactName: string | null;
+  sha256: string | null;
+  digest: string | null;
+  releaseUrl: string | null;
+  signatureName?: string;
+  signatureUrl?: string;
+  verificationCommand: string | null;
+  attestationCommand: string | null;
+  signingStatus: string;
+  recommendedInstallCommand?: string;
 };
 
 export type PlatformDownload = {

--- a/tests/download.spec.ts
+++ b/tests/download.spec.ts
@@ -37,10 +37,81 @@ test("download page exposes installer links", async ({ page }) => {
     page.locator('a[href="https://example.com/fake/linux.AppImage"]'),
   ).toBeVisible();
   await expect(
+    page.locator('a[href="https://example.com/fake/macos-aarch64.dmg"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator('a[href="https://example.com/fake/macos-x64.dmg"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator('a[href="https://example.com/fake/linux.rpm"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator('a[href="https://example.com/fake/linux.deb"]'),
+  ).toBeVisible();
+  await expect(
     page.locator(
       '#download a[href="https://github.com/shm11C3/HardwareVisualizer/releases/latest"]',
     ),
   ).toHaveCount(0);
+});
+
+test("download page exposes copyable per-asset SHA-256 values", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async () => undefined,
+      },
+    });
+  });
+  await page.goto("/download/");
+
+  const checksumSections = page.locator("#download [data-download-checksum]");
+
+  await expect(checksumSections).toHaveCount(6);
+
+  const windows = page.locator('[data-download-checksum="windows"]');
+  await expect(windows).not.toHaveAttribute("open", "");
+  await expect(windows.locator("summary")).toContainText("Checksum (SHA-256)");
+  await expect(windows.locator("summary")).not.toContainText(
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  );
+  const copyButton = windows.getByRole("button", { name: "Copy SHA-256" });
+  await expect(copyButton).toBeVisible();
+  await copyButton.hover();
+  await expect(windows.locator("[data-copy-tooltip]")).toBeVisible();
+  await copyButton.click();
+  await expect(windows).not.toHaveAttribute("open", "");
+  await expect(windows.getByRole("button", { name: "Copied" })).toBeVisible();
+  await windows.locator("summary").click({ position: { x: 10, y: 10 } });
+  await expect(windows).toHaveAttribute("open", "");
+  await expect(windows).toContainText(
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  );
+  await expect(
+    page.locator("#download [data-download-verification-link]"),
+  ).toHaveCount(0);
+  await expect(page.locator("#download")).not.toContainText(
+    "Learn how verification works",
+  );
+
+  await expect(page.locator("#download")).not.toContainText("Get-FileHash");
+  await expect(page.locator("#download")).not.toContainText(
+    "gh attestation verify",
+  );
+});
+
+test("download page warns when SHA-256 is unavailable", async ({ page }) => {
+  await page.goto("/download/");
+
+  const deb = page.locator('[data-download-checksum="linuxDeb"]');
+
+  await deb.locator("summary").click();
+  await expect(deb.locator("[data-checksum-warning]")).toContainText(
+    "Checksum unavailable",
+  );
 });
 
 test("JA download page keeps localized parallel navigation", async ({
@@ -70,10 +141,101 @@ test("JA download page keeps localized parallel navigation", async ({
   ).toBeVisible();
 });
 
+test("JA download page localizes checksum labels without command details", async ({
+  page,
+}) => {
+  await page.goto("/ja/download/");
+
+  const windows = page.locator('[data-download-checksum="windows"]');
+
+  await expect(windows.locator("summary")).toContainText(
+    "チェックサム (SHA-256)",
+  );
+  await expect(windows.locator("summary")).not.toContainText(
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  );
+  await expect(
+    windows.getByRole("button", { name: "SHA-256をコピー" }),
+  ).toBeVisible();
+  await windows.locator("summary").click();
+  await expect(
+    page.locator("#download [data-download-verification-link]"),
+  ).toHaveCount(0);
+  await expect(page.locator("#download")).not.toContainText(
+    "検証方法の詳細を見る",
+  );
+  await expect(page.locator("#download")).not.toContainText("Get-FileHash");
+  await expect(page.locator("#download")).not.toContainText(
+    "gh attestation verify",
+  );
+});
+
 test("verification page exposes official resource links", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          window.localStorage.setItem("copied-code", text);
+        },
+      },
+    });
+  });
   await page.goto("/verification/");
 
   await expect(page.locator("main > section#verification")).toBeVisible();
+  await expect(page.locator("[data-verification-info]")).toContainText("Info");
+  await expect(page.locator("[data-verification-info]")).toContainText(
+    "you do not need to force this step",
+  );
+  await expect(page.locator("#latest-commands")).toContainText(
+    "Latest release verification commands (Advanced)",
+  );
+  await expect(page.locator("main > section#verification")).toContainText(
+    "run the matching checksum command from the latest release verification commands",
+  );
+  await expect(
+    page.locator('main > section#verification a[href="#latest-commands"]'),
+  ).toBeVisible();
+  await expect(page.locator("main > section#verification")).toContainText(
+    "Get-FileHash",
+  );
+  await expect(page.locator("main > section#verification")).toContainText(
+    "shasum -a 256",
+  );
+  await expect(page.locator("main > section#verification")).toContainText(
+    "sha256sum",
+  );
+  await expect(page.locator("main > section#verification")).toContainText(
+    "gh attestation verify",
+  );
+  await expect(page.locator("main > section#verification")).toContainText(
+    "Authenticode signing pending",
+  );
+  await expect(page.locator("#latest-commands")).not.toContainText(
+    "winget install",
+  );
+  await expect(page.locator("#latest-commands")).not.toContainText(
+    "View GitHub Release",
+  );
+  const latestCommands = page.locator(
+    'section[aria-labelledby="latest-commands"]',
+  );
+  const copyCodeButtons = latestCommands.locator("[data-copy-code-button]");
+  await expect(copyCodeButtons.first()).toBeVisible();
+  const verificationCommandCopyButton = copyCodeButtons.nth(1);
+  await expect(verificationCommandCopyButton).toHaveAttribute(
+    "aria-label",
+    "Copy code",
+  );
+  await verificationCommandCopyButton.click();
+  await expect(verificationCommandCopyButton).toHaveAttribute(
+    "aria-label",
+    "Copied",
+  );
+  await expect
+    .poll(() => page.evaluate(() => window.localStorage.getItem("copied-code")))
+    .toContain("Get-FileHash");
   await expect(
     page.locator(
       'a[href="https://github.com/shm11C3/HardwareVisualizer/releases"]',
@@ -99,6 +261,34 @@ test("JA verification page keeps localized route structure", async ({
 
   await expect(page.locator("html")).toHaveAttribute("lang", "ja");
   await expect(page.locator("main > section#verification")).toBeVisible();
+  await expect(page.locator("[data-verification-info]")).toContainText("Info");
+  await expect(page.locator("[data-verification-info]")).toContainText(
+    "この手順を無理に実行する必要はありません",
+  );
+  await expect(page.locator("#latest-commands")).toContainText(
+    "最新リリースの検証コマンド（上級者向け）",
+  );
+  await expect(page.locator("main > section#verification")).toContainText(
+    "最新リリースの検証コマンド",
+  );
+  await expect(
+    page.locator('main > section#verification a[href="#latest-commands"]'),
+  ).toBeVisible();
+  await expect(page.locator("main > section#verification")).toContainText(
+    "Get-FileHash",
+  );
+  await expect(page.locator("main > section#verification")).toContainText(
+    "gh attestation verify",
+  );
+  await expect(page.locator("#latest-commands")).not.toContainText(
+    "GitHub Releaseを見る",
+  );
+  await expect(
+    page
+      .locator('section[aria-labelledby="latest-commands"]')
+      .locator("[data-copy-code-button]")
+      .first(),
+  ).toHaveAttribute("aria-label", "コードをコピー");
   await expect(
     page.locator('a[href*="docs/download-verification.ja.md"]').first(),
   ).toBeVisible();


### PR DESCRIPTION
- Introduced checksum verification for downloaded files, including SHA-256 values.
- Added copy functionality for SHA-256 checksums in the download component.
- Updated download page to display checksum information and copy buttons.
- Enhanced the download verification page with commands for verifying downloads.
- Localized new strings for checksum verification in English and Japanese.
- Updated tests to cover new checksum features and verification commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SHA-256 checksum display and one-click copy functionality to the download page
  * Introduced verification commands section with copyable commands for file integrity checking
  * Enhanced verification guidance with GitHub attestation and signature file verification support

* **Documentation**
  * Updated English and Japanese verification guides with step-by-step checksum verification procedures

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shm11C3/hardviz-webpage/pull/314)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->