### PR TITLE
feat: add v1.9.1 release notes

### DIFF
--- a/src/config/releaseNotes.ts
+++ b/src/config/releaseNotes.ts
@@ -1,3 +1,3 @@
 // Version of the changelog entry shown in the TOP page release-notes card.
 // Set this to null to follow the latest downloadable release.
-export const homeReleaseNotesVersion: string | null = "1.9.0";
+export const homeReleaseNotesVersion: string | null = "1.9.1";

--- a/src/config/releaseNotes.ts
+++ b/src/config/releaseNotes.ts
@@ -1,3 +1,3 @@
 // Version of the changelog entry shown in the TOP page release-notes card.
 // Set this to null to follow the latest downloadable release.
-export const homeReleaseNotesVersion: string | null = "1.9.1";
+export const homeReleaseNotesVersion: string | null = "1.9.0";

--- a/src/content/changelog/en/1.9.1.mdx
+++ b/src/content/changelog/en/1.9.1.mdx
@@ -1,0 +1,37 @@
+---
+lang: en
+version: 1.9.1
+date: 2026-06-25
+title: "v1.9.1"
+summary: "Reworked Transparent UI on macOS to use native vibrancy with a frosted-glass slider for lower GPU and power usage, and reframed the feature with a calmer Experimental badge."
+tags:
+  - Release
+  - Transparent UI
+  - Performance
+  - macOS
+  - Experimental
+---
+
+## What's Changed
+
+v1.9.1 refines the Transparent UI feature introduced in v1.9.0, with a focus on macOS performance.
+
+On macOS, the transparent and glass-blur effect previously relied on the CSS `backdrop-filter` blur, which kept the GPU and compositor under continuous load and noticeably increased power usage.
+This release switches macOS to native vibrancy (NSVisualEffectView), so the frosted-glass look is rendered by the system instead of being repainted every frame.
+
+The Transparent UI setting has also been reorganized into a dedicated Experimental features section.
+A calmer "Experimental" badge and a short note replace the earlier warning callout, while still making clear that the feature is experimental and may increase power usage, especially on macOS.
+
+## macOS Performance
+
+- Switched macOS Transparent UI to native vibrancy (NSVisualEffectView) instead of the CSS `backdrop-filter` blur, reducing GPU and power usage.
+- Added a 4-step frost slider (off / low / medium / high) on macOS, mapped to native materials and reusing the existing glass blur setting.
+- Rendered web UI surfaces as fully opaque on macOS so the native vibrancy effect shows through without per-frame compositing.
+
+## Transparent UI
+
+- Moved Transparent UI into a dedicated Experimental features section.
+- Replaced the warning callout with a calmer "Experimental" badge and a short note.
+- Kept guidance that the feature is experimental and may increase power usage, especially on macOS.
+
+**Full Changelog**: [v1.9.0...v1.9.1](https://github.com/shm11C3/HardwareVisualizer/compare/v1.9.0...v1.9.1)

--- a/src/content/changelog/ja/1.9.1.mdx
+++ b/src/content/changelog/ja/1.9.1.mdx
@@ -1,0 +1,37 @@
+---
+lang: ja
+version: 1.9.1
+date: 2026-06-25
+title: "v1.9.1"
+summary: "macOSのTransparent UIをネイティブvibrancyとすりガラス風スライダーに作り直してGPUと消費電力の負荷を軽減し、より落ち着いたExperimentalバッジに見直しました。"
+tags:
+  - リリース
+  - Transparent UI
+  - パフォーマンス
+  - macOS
+  - Experimental
+---
+
+## 変更内容
+
+v1.9.1では、v1.9.0で追加したTransparent UIを、macOSのパフォーマンスを中心に改善しました。
+
+これまでmacOSの透明・ガラスぼかし表現はCSSの`backdrop-filter`ぼかしに依存しており、GPUとコンポジターに継続的な負荷がかかって消費電力も目立って増加していました。
+今回のリリースではmacOSをネイティブvibrancy（NSVisualEffectView）に切り替え、すりガラス風の見た目を毎フレーム描き直すのではなくシステム側で描画するようにしました。
+
+また、Transparent UIの設定を専用のExperimental features（実験的機能）セクションにまとめ直しました。
+以前の警告表示に代えて、落ち着いた「Experimental」バッジと短い注記を表示しつつ、この機能が実験的であり特にmacOSで消費電力が増える可能性があることは引き続き明示しています。
+
+## macOSのパフォーマンス
+
+- macOSのTransparent UIをCSSの`backdrop-filter`ぼかしからネイティブvibrancy（NSVisualEffectView）に切り替え、GPUと消費電力の負荷を軽減しました。
+- macOSで4段階のすりガラススライダー（オフ / 低 / 中 / 高）を追加し、既存のガラスぼかし設定を再利用してネイティブマテリアルに対応付けました。
+- macOSでWeb UIの表面を完全に不透明で描画し、毎フレームの合成なしにネイティブvibrancyの効果が透けて見えるようにしました。
+
+## Transparent UI
+
+- Transparent UIを専用のExperimental features（実験的機能）セクションに移動しました。
+- 警告表示に代えて、より落ち着いた「Experimental」バッジと短い注記を表示するようにしました。
+- この機能が実験的であり、特にmacOSで消費電力が増える可能性があるという案内を引き続き表示しています。
+
+**Full Changelog**: [v1.9.0...v1.9.1](https://github.com/shm11C3/HardwareVisualizer/compare/v1.9.0...v1.9.1)


### PR DESCRIPTION
## Summary

Adds the changelog entries for **v1.9.1** ([upstream release](https://github.com/shm11C3/HardwareVisualizer/releases/tag/v1.9.1)).

The home-page release-notes card intentionally **stays on v1.9.0** — `homeReleaseNotesVersion` is left unchanged — so this PR only adds the new changelog pages without changing what the top page features.

v1.9.1 is a patch release that refines the Transparent UI feature introduced in v1.9.0, focused on macOS performance:

- **macOS native vibrancy** — replaces the CSS `backdrop-filter` blur with native vibrancy (NSVisualEffectView), reducing GPU and power usage ([#1726](https://github.com/shm11C3/HardwareVisualizer/pull/1726)).
- **4-step frost slider on macOS** — discrete off / low / medium / high control mapped to native materials, reusing the existing glass blur setting.
- **Opaque surfaces on macOS** — web UI surfaces paint fully opaque so the native effect shows through without per-frame compositing.
- **Calmer Experimental badge** — Transparent UI moves into a dedicated Experimental features section with a subtle "Experimental" badge and a short note, while still flagging higher power usage especially on macOS ([#1720](https://github.com/shm11C3/HardwareVisualizer/pull/1720)).

## Changes

- `src/content/changelog/en/1.9.1.mdx` — English changelog entry
- `src/content/changelog/ja/1.9.1.mdx` — Japanese changelog entry

The v1.9.1 notes are reachable at `/changelog/1.9.1/` (and `/ja/changelog/1.9.1/`) and appear in the changelog index; the top-page card continues to show v1.9.0.

## Verification

- `astro build` — succeeds; both `/changelog/1.9.1/` and `/ja/changelog/1.9.1/` pages generate, and the home-page card resolves to v1.9.0 in both locales
- `astro check` — 0 errors, 0 warnings
- `biome check` — clean
- `playwright test tests/home.spec.ts` — 12/12 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7CUKzwAhrazjYLWwS86a2